### PR TITLE
fix GridFSBucketWriteStream destroy

### DIFF
--- a/lib/gridfs.js
+++ b/lib/gridfs.js
@@ -288,7 +288,11 @@ class GridFSStorage extends EventEmitter {
 			disableMD5: opts.disableMD5
 		};
 		gfs = new GridFSBucket(this.db, {bucketName: opts.bucketName});
-		return gfs.openUploadStream(opts.filename, settings);
+		const upload = gfs.openUploadStream(opts.filename, settings);
+		// no-op destroy function to prevent pump from throwing,
+		// because GridFSBucketWriteStream doesn't implement it properly, but pump calls it on stream error
+		upload.destroy = () => {};
+		return upload;
 	}
 
 	/**


### PR DESCRIPTION
### PR Checklist

Verify that you did the following:

- [ ] Opened an issue to track and discuss the problem you are trying to solve.
- [x] Submitted the changes using a new branch in your fork of this repo.
- [ ] Added test for the changes and checked that code coverage didn't diminished if possible. 
- [x] Docs were updated using jsdoc style comments when necessary. *(not necessary)*

#### Related issue
--

#### Describe what you did

GridFSBucketWriteStream doesn't implement the node stream interface properly. `destroy()` does not work, but throws "TypeError: Cannot read property 'destroyed' of undefined" when called.

If an error occurs while writing to the grid, this error will correctly be returned by the callback and through the "streamError" event - but pump will throw an additional error, because it tries to call `destroy()` on the stream.

Neither pump nor GridFSBucketWriteStream are really at fault, it's the combination of both. Thats why I suggest this change. This just makes `destroy()` on the writeStream a no-op, so it can't fail.

#### Is this a breaking change?

- [ ] Yes
- [x] No

#### Other information
