### PR TITLE
Update gridfs.ts

### DIFF
--- a/src/gridfs.ts
+++ b/src/gridfs.ts
@@ -349,6 +349,10 @@ export class GridFsStorage extends EventEmitter implements StorageEngine {
 			};
 
 			const emitFile = (f) => {
+				if (f === undefined) {
+					// @ts-ignore - outdated types file this does exist
+					f = writeStream.gridFSFile;
+				}
 				const storedFile: GridFile = {
 					id: f._id,
 					filename: f.filename,


### PR DESCRIPTION
### PR Checklist

Verify that you did the following:

- [ x ] Opened an issue to track and discuss the problem you are trying to solve. (Someone else has this opened already)
- [ x ] Submitted the changes using a new branch in your fork of this repo.
- [ x ] Added test for the changes and checked that code coverage didn't diminished if possible. (No test added but checked code coverage) 
- [ x ] Docs were updated using jsdoc style comments when necessary. (N/A)

#### Related issue

Issue: #560 

#### Describe what you did

GridFSBucket doesn't pass the file into a callback anymore, instead it sets the value of gridFSFile when the finish event is triggered. I added a check so to see `f` was undefined (handles if someone is using old driver and f was passed though callback) if it was then get the file from `writeStream.gridFSFile`

#### Is this a breaking change?
No, fixes broken compatibility with current mongodb driver

- [ ] Yes
- [ x ] No
