### PR TITLE
Add Cloud Agent development environment setup

### DIFF
--- a/.cursor/start-mongo.sh
+++ b/.cursor/start-mongo.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Idempotently start a local MongoDB for the test suite (Cloud Agent VM has no
+# systemd, so mongod is launched directly instead of via systemctl/docker).
+set -euo pipefail
+
+MONGO_PORT="${MONGO_PORT:-27017}"
+DATA_DIR="${MONGO_DATA_DIR:-$HOME/.cache/mongodb/data}"
+LOG_DIR="${MONGO_LOG_DIR:-$HOME/.cache/mongodb}"
+LOG_FILE="$LOG_DIR/mongod.log"
+PID_FILE="$LOG_DIR/mongod.pid"
+
+mkdir -p "$DATA_DIR" "$LOG_DIR"
+
+# Already accepting connections? Nothing to do.
+if mongosh --quiet --port "$MONGO_PORT" --eval 'db.runCommand({ ping: 1 })' >/dev/null 2>&1; then
+  echo "MongoDB already running on port $MONGO_PORT"
+  exit 0
+fi
+
+# Clean up a stale lock left by a previous boot before starting.
+rm -f "$DATA_DIR/mongod.lock"
+
+mongod \
+  --dbpath "$DATA_DIR" \
+  --port "$MONGO_PORT" \
+  --bind_ip 127.0.0.1 \
+  --logpath "$LOG_FILE" \
+  --pidfilepath "$PID_FILE" \
+  --fork
+
+# Wait until it accepts connections.
+for _ in $(seq 1 30); do
+  if mongosh --quiet --port "$MONGO_PORT" --eval 'db.runCommand({ ping: 1 })' >/dev/null 2>&1; then
+    echo "MongoDB is ready on port $MONGO_PORT"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "MongoDB failed to become ready; last log lines:" >&2
+tail -n 20 "$LOG_FILE" >&2 || true
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up a reproducible Cloud Agent development environment for `multer-gridfs-storage`.

The test suite requires a live MongoDB. Cloud Agent VMs have no Docker/systemd, so instead of the local `docker compose` flow this adds a small, idempotent helper that launches a native `mongod` on `27017` (matching `docker-compose.yml`'s `mongo:8.0`). The Cloud Agent environment runs this as its `start` command; the base image (captured in a snapshot) has MongoDB 8.0 preinstalled.

## Changes

- `.cursor/start-mongo.sh` — idempotent MongoDB launcher: creates the data dir, no-ops if MongoDB already answers on the port, clears any stale lock, `mongod --fork`, then waits for readiness.

## Environment config (proposed separately via the environment panel)

- `install`: `npm ci` (also resolves the `mongodb` / `multer` peer deps)
- `start`: `bash .cursor/start-mongo.sh`

## Validation

All run inside the VM against the local MongoDB:

- `npm run typecheck` — passed
- `npm test` — 133 tests passed (19 files)
- `npm run coverage` — 100% statements/functions/lines, 99.54% branches
- `npx eslint .` and `prettier --check` — clean
- Install + start scripts verified idempotent (run twice)

This helper only affects the Cloud Agent environment; it does not change the library or the existing local `docker compose` workflow documented in `AGENTS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44581916-af22-42eb-a8af-4b35c5dba2b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44581916-af22-42eb-a8af-4b35c5dba2b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

